### PR TITLE
fix: transformer not working with custom NodeJS path

### DIFF
--- a/src/transformer.js
+++ b/src/transformer.js
@@ -11,7 +11,7 @@ const transformer = (options = {}) => (source, filename) => {
   if (preprocess) {
     const preprocessor = require.resolve('./preprocess.js')
     processed = execSync(`node ${preprocessor}`, {
-      env: { source, filename }
+      env: { PATH: process.env.PATH, source, filename }
     }).toString()
   }
 


### PR DESCRIPTION
## Problem
![Screenshot 2020-03-05 at 8 11 01 PM](https://user-images.githubusercontent.com/242017/75980491-8481a280-5f1d-11ea-8b38-9d12610cde06.png)

## Root Cause
I'm currently using asdf to manage my NodeJS versions that are installed into custom path which would cause `child_process.execSync` unable to find the node binary.

## Solution
While it's very likely different users would have installed their NodeJS into custom path, it'd be nicer to ensure `transformer` executes with the same environment as its parent process.