### PR TITLE
docs(readme): add toc entry for typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Simply precompiles Svelte components before importing them into Jest tests.
 - [Why not just use x?](#why-not-just-use-x)
 - [Installation](#installation)
   - [Babel](#babel)
+  - [TypeScript](#typescript)
   - [Preprocess](#preprocess)
 - [Options](#options)
 - [Testing Library](#testing-library)


### PR DESCRIPTION
Just realised I should have run the `toc` script as part of #10

Sorry for the PR noise!