### PR TITLE
Adds rootMode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,13 +143,16 @@ They are loaded from `svelte.config.js`.
 `compilerOptions` (default: {}): Use this to pass in 
 [Svelte compiler options](https://svelte.dev/docs#svelte_compile).
 
+`rootMode` (default: ""): Pass in `upward` to walk up from each file's directory and return the first `svelte.config.js` found, or throw an error if no config file is discovered. This is particularly useful in a monorepo using Jest projects as it allows each package to have it's own `svelte.config.js`, and is similar to Babel's `rootMode`. Default behaviour is to look for a `svelte.config.js` in the root directory.
+
 ```json
 "transform": {
   "^.+\\.js$": "babel-jest",
   "^.+\\.svelte$": ["svelte-jester", { 
     "preprocess": false,
     "debug": false,
-    "compilerOptions": {}
+    "compilerOptions": {},
+    "rootMode": ""
   }]
 }
 ```

--- a/src/preprocess.js
+++ b/src/preprocess.js
@@ -1,10 +1,8 @@
-const path = require('path')
 const svelte = require('svelte/compiler')
 const { cosmiconfigSync } = require('cosmiconfig')
 
-const { source, filename } = process.env
-const configPath = path.join(process.cwd(), 'svelte.config.js')
-const config = cosmiconfigSync().load(configPath).config
+const { source, filename, svelteConfig } = process.env
+const config = cosmiconfigSync().load(svelteConfig).config
 
 svelte
   .preprocess(source, config.preprocess || {}, { filename })

--- a/src/svelteconfig.js
+++ b/src/svelteconfig.js
@@ -1,0 +1,23 @@
+const fs = require('fs')
+const path = require('path')
+
+const configFilename = 'svelte.config.js'
+
+exports.getSvelteConfig = (rootMode, filename) => {
+  const configDir = rootMode === 'upward'
+    ? getConfigDir(path.dirname(filename))
+    : getConfigDir(process.cwd())
+  return path.resolve(configDir, configFilename)
+}
+
+const getConfigDir = (searchDir) => {
+  if (fs.existsSync(path.join(searchDir, configFilename))) {
+    return searchDir
+  }
+  else if (searchDir === process.cwd()) {
+    throw Error(`Could not find ${configFilename}`)
+  }
+  else {
+    return getConfigDir(path.resolve(searchDir, '..'))
+  }
+}

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -2,16 +2,18 @@
 const { basename } = require('path')
 const { execSync } = require('child_process')
 const svelte = require('svelte/compiler')
+const { getSvelteConfig } = require('./svelteconfig.js')
 
 const transformer = (options = {}) => (source, filename) => {
-  const { debug, compilerOptions, preprocess } = options
+  const { debug, compilerOptions, preprocess, rootMode } = options
+  const svelteConfig = getSvelteConfig(rootMode, filename)
 
   let processed = source
 
   if (preprocess) {
     const preprocessor = require.resolve('./preprocess.js')
     processed = execSync(`node --unhandled-rejections=strict --abort-on-uncaught-exception ${preprocessor}`, {
-      env: { PATH: process.env.PATH, source, filename }
+      env: { PATH: process.env.PATH, source, filename, svelteConfig }
     }).toString()
   }
 


### PR DESCRIPTION
Fixes #12 

In large projects, such as monorepos, Jest projects can be used to run tests across multiple packages. Each package may have its own `svelte.config.js` file. However, current functionality is to only look for `svelte.config.js` in the root directory.

This PR adds the following:
- New rootMode option
- When rootMode is set to "upward", walk up from the directory of the file being transformed until the first `svelte.config.js` is found, and pass this to the preprocessor
- If the cwd is reached and it does not contain a `svelte.config.js`, throw an Error
- If rootMode is not set to "upward", look for a `svelte.config.js` in the root (no change to current behaviour)
- Documentation updated with new option
