### PR TITLE
fix: add svelteconfig.js to files pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   ],
   "files": [
     "src/transformer.js",
-    "src/preprocess.js"
+    "src/preprocess.js",
+    "src/svelteconfig.js"
   ],
   "scripts": {
     "toc": "doctoc README.md",


### PR DESCRIPTION
Urgent fix - svelteconfig.js is not included in the package.json