### PR TITLE
feat: improved rootMode to handle more monorepo use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,14 @@ They are loaded from `svelte.config.js`.
 `compilerOptions` (default: {}): Use this to pass in 
 [Svelte compiler options](https://svelte.dev/docs#svelte_compile).
 
-`rootMode` (default: ""): Pass in `upward` to walk up from each file's directory and return the first `svelte.config.js` found, or throw an error if no config file is discovered. This is particularly useful in a monorepo using Jest projects as it allows each package to have it's own `svelte.config.js`, and is similar to Babel's `rootMode`. Default behaviour is to look for a `svelte.config.js` in the root directory.
+`rootMode` (default: ""): Pass in `upward` to walk up from the transforming file's directory and use the first `svelte.config.js` found, or throw an error if no config file is discovered. This is particularly useful in a monorepo as it allows you to:
+- Run tests from the worktree root using Jest projects where you only want to put `svelte.config.js` in workspace folders, and not in the root.
+- Run tests from the worktree root using Jest projects, but have different `svelte.config.js` configurations for individual workspaces.
+- Have one common `svelte.config.js` in your worktree root (or any directory above the file being transformed) without needing individual `svelte.config.js` files in each workspace. _Note - this root config file can be overriden if necessary by putting another config file into a workspace folder_
+
+The default mode is to load `svelte.config.js` from the current project root to avoid the risk of accidentally loading a `svelte.config.js` from outside the current project folder.
+
+When `upward` is set it will stop at the first config file it finds above the file being transformed, but will walk up the directory structure all the way to the filesystem root if it cannot find any config file. This means that if there is no `svelte.config.js` file in the project above the file being transformed, it is always possible that someone will have a forgotten `svelte.config.js` in their home directory which could cause unexpected errors in your builds.
 
 ```json
 "transform": {

--- a/src/svelteconfig.js
+++ b/src/svelteconfig.js
@@ -6,16 +6,23 @@ const configFilename = 'svelte.config.js'
 exports.getSvelteConfig = (rootMode, filename) => {
   const configDir = rootMode === 'upward'
     ? getConfigDir(path.dirname(filename))
-    : getConfigDir(process.cwd())
-  return path.resolve(configDir, configFilename)
+    : process.cwd()
+  const configFile = path.resolve(configDir, configFilename)
+
+  if (!fs.existsSync(configFile)) {
+    throw Error(`Could not find ${configFilename}`)
+  }
+
+  return configFile
 }
 
 const getConfigDir = (searchDir) => {
   if (fs.existsSync(path.join(searchDir, configFilename))) {
     return searchDir
-  } else if (searchDir === process.cwd()) {
-    throw Error(`Could not find ${configFilename}`)
-  } else {
-    return getConfigDir(path.resolve(searchDir, '..'))
   }
+
+  const parentDir = path.resolve(searchDir, '..')
+  return parentDir !== searchDir
+    ? getConfigDir(parentDir)
+    : searchDir // Stop walking at filesystem root
 }


### PR DESCRIPTION
### Better monorepo support :tada:

The `rootMode: 'upward'` option has been re-written to support more use cases for monorepos. 

**Existing implementation**
Setting the `rootMode: 'upward'` option allows users to have individual `svelte.config.js` files in workspace folders, rather than the worktree root when running tests using Jest projects in the worktree root.

**New features**
Setting `rootMode: upward` now locates the nearest`svelte.config.js` file relative to the transforming file. This allows the user to:
- Have one common `svelte.config.js` file in the worktree folder without requiring each workspace folder to have an individual `svelte.config.js` file
- Override a common configuration with a workspace specific `svelte.config.js` if required
- Have individual `svelte.config.js` files in each workspace and no common configuration
- In all cases, tests can be run from both the worktree root using Jest projects or from within a workspace folder, and the appropriate config file will be used
- Documentation has been updated to reflect the change

This is a non-breaking change:
- Default (no rootMode set) continues to work as expected
- The existing implementation  of `rootMode: upward` continues to work as expected

**Benefits**
This makes the transformer much more flexible for usage in monorepos, as it gives the user choice on where they want to locate the `svelte.config.js` files. It also means they no longer need to have a local `svelte.config.js` file in each workspace that only imports and re-exports a base `svelte.config.js` if there is no requirement to override this.

Closes #12 

