### PR TITLE
Adds maxBuffer option that sets buffer limit for preprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ The default mode is to load `svelte.config.js` from the current project root to 
 
 When `upward` is set it will stop at the first config file it finds above the file being transformed, but will walk up the directory structure all the way to the filesystem root if it cannot find any config file. This means that if there is no `svelte.config.js` file in the project above the file being transformed, it is always possible that someone will have a forgotten `svelte.config.js` in their home directory which could cause unexpected errors in your builds.
 
+`maxBuffer` (default: 10485760): Sets limit for buffer when `preprocess` is true. It defines the largest amount of data in bytes allowed on stdout or stderr for [child_process.spawnSync](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options). If exceeded, the child process is terminated and any output is truncated. The default value of 10Mb overrides Node's default value of 1Mb.
+
 ```json
 "transform": {
   "^.+\\.js$": "babel-jest",
@@ -165,7 +167,8 @@ When `upward` is set it will stop at the first config file it finds above the fi
     "preprocess": false,
     "debug": false,
     "compilerOptions": {},
-    "rootMode": ""
+    "rootMode": "",
+    "maxBuffer": 15000000
   }]
 }
 ```

--- a/src/__tests__/transformer.test.js
+++ b/src/__tests__/transformer.test.js
@@ -44,4 +44,11 @@ describe('transformer', () => {
     const esInterop = 'Object.defineProperty(exports, "__esModule", { value: true });'
     expect(global.window.console.log).toHaveBeenCalledWith(code.replace(esInterop, ''))
   })
+
+  it('should accept maxBuffer option for preprocess buffer limit', () => {
+    expect(
+      () => runTransformer('SassComp', { preprocess: true, maxBuffer: 1 })
+    ).toThrow('spawnSync /bin/sh ENOBUFS');
+    runTransformer('SassComp', { preprocess: true, maxBuffer: 5 * 1024 * 1024 })
+  })
 })

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -5,7 +5,7 @@ const svelte = require('svelte/compiler')
 const { getSvelteConfig } = require('./svelteconfig.js')
 
 const transformer = (options = {}) => (source, filename) => {
-  const { debug, compilerOptions, preprocess, rootMode } = options
+  const { debug, compilerOptions, preprocess, rootMode, maxBuffer } = options
 
   let processed = source
 
@@ -13,7 +13,8 @@ const transformer = (options = {}) => (source, filename) => {
     const svelteConfig = getSvelteConfig(rootMode, filename)
     const preprocessor = require.resolve('./preprocess.js')
     processed = execSync(`node --unhandled-rejections=strict --abort-on-uncaught-exception "${preprocessor}"`, {
-      env: { PATH: process.env.PATH, source, filename, svelteConfig }
+      env: { PATH: process.env.PATH, source, filename, svelteConfig },
+      maxBuffer: maxBuffer || 10 * 1024 * 1024
     }).toString()
   }
 


### PR DESCRIPTION
Solves https://github.com/mihar-22/svelte-jester/issues/20

This allows to avoid buffer overflow when running transformer with preprocess due to Node's default maxBuffer of 1Mb. 
Docs + tests updated.

Default is 10Mb. Allows to override by providing `maxBuffer` option to transformer

Otherwise, if the source is large (e.g. using TailwindCSS) it can throw the following error:

```
> jest src

 FAIL  src/App.test.js
  ● Test suite failed to run

    spawnSync /bin/sh ENOBUFS

      at Object.process (node_modules/svelte-jester/src/transformer.js:15:17)
      at ScriptTransformer.transformSource (node_modules/@jest/transform/build/ScriptTransformer.js:464:35)
      at ScriptTransformer._transformAndBuildScript (node_modules/@jest/transform/build/ScriptTransformer.js:569:40)
      at ScriptTransformer.transform (node_modules/@jest/transform/build/ScriptTransformer.js:607:25)
```