### PR TITLE
feat: allow user to specify `svelte.config` path

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,26 @@ To enable TypeScript support you'll need to setup [`svelte-preprocess`](https://
       "svelte"
     ]
   ```
+  However if you do not want to create a `svelte.config.js` at the root of your
+  project or you wish to use a custom config just for tests, you may pass the
+  path to the config file to the `preprocess` option thus:
 
+  ```json
+    "transform": {
+      "^.+\\.svelte$": [
+        "svelte-jester",
+        {
+          "preprocess": "/some/path/to/svelte.config.js"
+        }
+      ],
+      "^.+\\.ts$": "ts-jest"
+    },
+    "moduleFileExtensions": [
+      "js",
+      "ts",
+      "svelte"
+    ]
+  ```
 Note that TypeScript supports ES modules, so if you were previously using babel-jest just for ES module transpilation, you can remove babel-jest, babel, and any associated presets and config.
 
 By default, ts-jest will only transpile .ts files though, so if you want to continue using ES modules in .js files, you'll need to configure ts-jest to process .js files as well.

--- a/_svelte.config.js
+++ b/_svelte.config.js
@@ -1,0 +1,8 @@
+const { replace } = require("svelte-preprocess");
+
+module.exports = {
+  preprocess: [
+    // strip style tag
+    replace([[/<!--[^]*?-->|<style(\s[^]*?)?(?:>([^]*?)<\/style>|\/>)/gi, ""]]),
+  ],
+};

--- a/src/__tests__/transformer.test.js
+++ b/src/__tests__/transformer.test.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const path = require('path')
 const transformer = require('../transformer')
 
 const runTransformer = (filename, options) => {
@@ -19,6 +20,11 @@ describe('transformer', () => {
 
   it('should transform when using sass preprocessor', () => {
     runTransformer('SassComp', { preprocess: true })
+  })
+
+  it('should transform when using full path to preprocess', () => {
+    const preprocessPath = path.resolve(__dirname, '../../_svelte.config.js')
+    runTransformer('SassComp', { preprocess: preprocessPath })
   })
 
   // TODO: it works but it's really slow, it might have to do with the preprocessor.

--- a/src/svelteconfig.js
+++ b/src/svelteconfig.js
@@ -3,11 +3,17 @@ const path = require('path')
 
 const configFilename = 'svelte.config.js'
 
-exports.getSvelteConfig = (rootMode, filename) => {
-  const configDir = rootMode === 'upward'
-    ? getConfigDir(path.dirname(filename))
-    : process.cwd()
-  const configFile = path.resolve(configDir, configFilename)
+exports.getSvelteConfig = (rootMode, filename, preprocess) => {
+  let configFile = ''
+
+  if ('boolean' === typeof preprocess) {
+    const configDir = rootMode === 'upward'
+      ? getConfigDir(path.dirname(filename))
+      : process.cwd()
+    configFile = path.resolve(configDir, configFilename)
+  } else if('string' === typeof preprocess) {
+    configFile = preprocess
+  }
 
   if (!fs.existsSync(configFile)) {
     throw Error(`Could not find ${configFilename}`)

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -10,7 +10,7 @@ const transformer = (options = {}) => (source, filename) => {
   let processed = source
 
   if (preprocess) {
-    const svelteConfig = getSvelteConfig(rootMode, filename)
+    const svelteConfig = getSvelteConfig(rootMode, filename, preprocess)
     const preprocessor = require.resolve('./preprocess.js')
     processed = execSync(`node --unhandled-rejections=strict --abort-on-uncaught-exception "${preprocessor}"`, {
       env: { PATH: process.env.PATH, source, filename, svelteConfig },


### PR DESCRIPTION
I often use a custom `svelte.config.js` file for tests. This pull request allows users to specify the path to their config file.