### PR TITLE
fix: allow svelte.config.cjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ To do this, update the file glob above, and follow the instructions in the [ts-j
 
 ### Preprocess
 
-Preprocessors are loaded from `svelte.config.js`.
+Preprocessors are loaded from `svelte.config.js` or `svelte.config.cjs`.
 
 Add the following to your Jest config
 
@@ -161,21 +161,21 @@ Create a `svelte.config.js` file and configure it, see
 ## Options
 
 `preprocess` (default: false): Pass in `true` if you are using Svelte preprocessors. 
-They are loaded from `svelte.config.js`.
+They are loaded from `svelte.config.js` or `svelte.config.cjs`.
 
 `debug` (default: false): If you'd like to see the output of the compiled code then pass in `true`.
 
 `compilerOptions` (default: {}): Use this to pass in 
 [Svelte compiler options](https://svelte.dev/docs#svelte_compile).
 
-`rootMode` (default: ""): Pass in `upward` to walk up from the transforming file's directory and use the first `svelte.config.js` found, or throw an error if no config file is discovered. This is particularly useful in a monorepo as it allows you to:
+`rootMode` (default: ""): Pass in `upward` to walk up from the transforming file's directory and use the first `svelte.config.js` or `svelte.config.cjs` found, or throw an error if no config file is discovered. This is particularly useful in a monorepo as it allows you to:
 - Run tests from the worktree root using Jest projects where you only want to put `svelte.config.js` in workspace folders, and not in the root.
 - Run tests from the worktree root using Jest projects, but have different `svelte.config.js` configurations for individual workspaces.
 - Have one common `svelte.config.js` in your worktree root (or any directory above the file being transformed) without needing individual `svelte.config.js` files in each workspace. _Note - this root config file can be overriden if necessary by putting another config file into a workspace folder_
 
-The default mode is to load `svelte.config.js` from the current project root to avoid the risk of accidentally loading a `svelte.config.js` from outside the current project folder.
+The default mode is to load `svelte.config.js` or `svelte.config.cjs` from the current project root to avoid the risk of accidentally loading a config file from outside the current project folder.
 
-When `upward` is set it will stop at the first config file it finds above the file being transformed, but will walk up the directory structure all the way to the filesystem root if it cannot find any config file. This means that if there is no `svelte.config.js` file in the project above the file being transformed, it is always possible that someone will have a forgotten `svelte.config.js` in their home directory which could cause unexpected errors in your builds.
+When `upward` is set it will stop at the first config file it finds above the file being transformed, but will walk up the directory structure all the way to the filesystem root if it cannot find any config file. This means that if there is no `svelte.config.js` or `svelte.config.cjs` file in the project above the file being transformed, it is always possible that someone will have a forgotten config file in their home directory which could cause unexpected errors in your builds.
 
 `maxBuffer` (default: 10485760): Sets limit for buffer when `preprocess` is true. It defines the largest amount of data in bytes allowed on stdout or stderr for [child_process.spawnSync](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options). If exceeded, the child process is terminated and any output is truncated. The default value of 10Mb overrides Node's default value of 1Mb.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.3.0",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
-        "cosmiconfig": "^6.0.0"
+        "cosmiconfig": "^7.0.0"
       },
       "devDependencies": {
         "@types/jest": "^25.1.2",
@@ -723,7 +723,6 @@
         "jest-resolve": "^25.5.1",
         "jest-util": "^25.5.0",
         "jest-worker": "^25.5.0",
-        "node-notifier": "^6.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^3.1.0",
@@ -3030,18 +3029,18 @@
       "dev": true
     },
     "node_modules/cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+      "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
+        "import-fresh": "^3.2.1",
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
+        "yaml": "^1.10.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/cross-spawn": {
@@ -3585,8 +3584,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -5556,7 +5554,6 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -6702,7 +6699,6 @@
         "@types/graceful-fs": "^4.1.2",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-serializer": "^25.5.0",
         "jest-util": "^25.5.0",
@@ -14574,15 +14570,15 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+      "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
       "requires": {
         "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
+        "import-fresh": "^3.2.1",
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
+        "yaml": "^1.10.0"
       }
     },
     "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "svelte": ">= 3"
   },
   "dependencies": {
-    "cosmiconfig": "^6.0.0"
+    "cosmiconfig": "^7.0.0"
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",

--- a/src/__tests__/fixtures/svelte.config.cjs
+++ b/src/__tests__/fixtures/svelte.config.cjs
@@ -1,0 +1,7 @@
+const { replace } = require("svelte-preprocess");
+
+module.exports = {
+  preprocess: [
+    replace([[/Hello/gi, "Bye"]]),
+  ],
+};

--- a/src/__tests__/transformer.test.js
+++ b/src/__tests__/transformer.test.js
@@ -27,6 +27,13 @@ describe('transformer', () => {
     runTransformer('SassComp', { preprocess: preprocessPath })
   })
 
+  it('should search for "svelte.config.cjs" as well as "svelte.config.js"', () => {
+    const results = runTransformer('BasicComp', { preprocess: true, rootMode: "upward" })
+    // this is a little brittle, but it demonstrates that the replacements in
+    // "svelte.config.cjs" are working
+    expect(results).toContain('text("Bye ");')
+  })
+
   // TODO: it works but it's really slow, it might have to do with the preprocessor.
   // it('should transform when using typescript preprocessor', () => {
   //   runTransformer('TypescriptComp', { preprocess: true })


### PR DESCRIPTION
Addresses #35:
- Update Cosmiconfig to v7, which allows "svelte.config.cjs"
- Search for "svelte.config.cjs" as well as "svelte.config.js" when preprocess is `true`.

I don't love the test I added since it depends on the code that svelte generates, but I didn't want to make it too complex. Let me know if you want me to make changes. I'm not very available for the next 48 hours so if you want to make changes yourself or if someone else opens a better PR, I'm not too precious about my contribution -- I just selfishly want to be able to use `svelte.config.cjs` myself!