### PR TITLE
Support Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "devDependencies": {
         "@sveltejs/adapter-static": "^1.0.0-next.10",
         "@types/jest": "^26.0.23",
         "doctoc": "^2.0.0",
-        "esbuild": "^0.12.1",
+        "esbuild": "^0.12.5",
         "esbuild-jest": "^0.5.0",
         "jest": "^26.6.3",
         "jest-circus": "^26.6.3",
@@ -20,13 +20,14 @@
         "standard-version": "^9.3.0",
         "svelte": "^3.18.2",
         "svelte-preprocess": "^4.7.3",
-        "typescript": "^4.2.4",
+        "typescript": "^4.3.2",
         "why-is-node-running": "^2.2.0"
       },
       "engines": {
         "node": ">= 14"
       },
       "peerDependencies": {
+        "jest": "<= 26",
         "svelte": ">= 3"
       }
     },
@@ -760,7 +761,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -1629,16 +1629,16 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
       "dev": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.649",
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.70"
+        "node-releases": "^1.1.71"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1740,10 +1740,14 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001202",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001202.tgz",
-      "integrity": "sha512-ZcijQNqrcF8JNLjzvEiXqX4JUYxoZa7Pvcsd9UD8Kz4TvhTonOSNRsK+qtvpVL4l6+T1Rh4LFtLfnNWg6BGWCQ==",
-      "dev": true
+      "version": "1.0.30001230",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
+      "integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -3560,9 +3564,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.692",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.692.tgz",
-      "integrity": "sha512-Ix+zDUAXWZuUzqKdhkgN5dP7ZM+IwMG4yAGFGDLpGJP/3vNEEwuHG1LIhtXUfW0FFV0j38t5PUv2n/3MFSRviQ==",
+      "version": "1.3.742",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.742.tgz",
+      "integrity": "sha512-ihL14knI9FikJmH2XUIDdZFWJxvr14rPSdOhJ7PpS27xbz8qmaRwCwyg/bmFwjWKmWK9QyamiCZVCvXm5CH//Q==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -3679,9 +3683,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.1.tgz",
-      "integrity": "sha512-WfQ00MKm/Y4ysz1u9PCUAsV66k5lbrcEvS6aG9jhBIavpB94FBdaWeBkaZXxCZB4w+oqh+j4ozJFWnnFprOXbg==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.5.tgz",
+      "integrity": "sha512-vcuP53pA5XiwUU4FnlXM+2PnVjTfHGthM7uP1gtp+9yfheGvFFbq/KyuESThmtoHPUrfZH5JpxGVJIFDVD1Egw==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -3729,8 +3733,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -5649,7 +5652,6 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -6757,7 +6759,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -11551,9 +11552,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -13582,16 +13583,16 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.649",
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.70"
+        "node-releases": "^1.1.71"
       }
     },
     "bser": {
@@ -13667,9 +13668,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001202",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001202.tgz",
-      "integrity": "sha512-ZcijQNqrcF8JNLjzvEiXqX4JUYxoZa7Pvcsd9UD8Kz4TvhTonOSNRsK+qtvpVL4l6+T1Rh4LFtLfnNWg6BGWCQ==",
+      "version": "1.0.30001230",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
+      "integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
       "dev": true
     },
     "capture-exit": {
@@ -15047,9 +15048,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.692",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.692.tgz",
-      "integrity": "sha512-Ix+zDUAXWZuUzqKdhkgN5dP7ZM+IwMG4yAGFGDLpGJP/3vNEEwuHG1LIhtXUfW0FFV0j38t5PUv2n/3MFSRviQ==",
+      "version": "1.3.742",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.742.tgz",
+      "integrity": "sha512-ihL14knI9FikJmH2XUIDdZFWJxvr14rPSdOhJ7PpS27xbz8qmaRwCwyg/bmFwjWKmWK9QyamiCZVCvXm5CH//Q==",
       "dev": true
     },
     "emittery": {
@@ -15139,9 +15140,9 @@
       }
     },
     "esbuild": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.1.tgz",
-      "integrity": "sha512-WfQ00MKm/Y4ysz1u9PCUAsV66k5lbrcEvS6aG9jhBIavpB94FBdaWeBkaZXxCZB4w+oqh+j4ozJFWnnFprOXbg==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.5.tgz",
+      "integrity": "sha512-vcuP53pA5XiwUU4FnlXM+2PnVjTfHGthM7uP1gtp+9yfheGvFFbq/KyuESThmtoHPUrfZH5JpxGVJIFDVD1Egw==",
       "dev": true
     },
     "esbuild-jest": {
@@ -21155,9 +21156,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@sveltejs/adapter-static": "^1.0.0-next.10",
     "@types/jest": "^26.0.23",
     "doctoc": "^2.0.0",
-    "esbuild": "^0.12.1",
+    "esbuild": "^0.12.5",
     "esbuild-jest": "^0.5.0",
     "jest": "^26.6.3",
     "jest-circus": "^26.6.3",
@@ -59,7 +59,7 @@
     "standard-version": "^9.3.0",
     "svelte": "^3.18.2",
     "svelte-preprocess": "^4.7.3",
-    "typescript": "^4.2.4",
+    "typescript": "^4.3.2",
     "why-is-node-running": "^2.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "release": "yarn validate && standard-version"
   },
   "peerDependencies": {
-    "svelte": ">= 3"
+    "svelte": ">= 3",
+    "jest": "<= 26"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^1.0.0-next.10",

--- a/src/__tests__/fixtures/shared/commonTransformerTests.js
+++ b/src/__tests__/fixtures/shared/commonTransformerTests.js
@@ -47,7 +47,7 @@ const sharedTests = (dependencies) => {
   it('should accept maxBuffer option for preprocess buffer limit', () => {
     expect(
       () => runTransformer('SassComp', { preprocess: true, maxBuffer: 1 })
-    ).toThrow('spawnSync /bin/sh ENOBUFS')
+    ).toThrow(/^spawnSync .* ENOBUFS$/)
     runTransformer('SassComp', { preprocess: true, maxBuffer: 5 * 1024 * 1024 })
   })
 

--- a/src/preprocess.js
+++ b/src/preprocess.js
@@ -1,7 +1,8 @@
 import { preprocess } from 'svelte/compiler'
+import { pathToFileURL } from 'url'
 
 const { source, filename, svelteConfig } = process.env
-import(svelteConfig).then(configImport => {
+import(pathToFileURL(svelteConfig)).then(configImport => {
   // ESM or CommonJS
   const config = configImport.default ? configImport.default : configImport
 


### PR DESCRIPTION
Dynamic Imports on Windows only work for file-urls. So I added these to the `preprocess.js`.

I also noticed, the tests don't run on Windows. This was because of the substring match in one of the tests. It matched only for `/bin/sh`.

Since svelte-jester currently does not work on Jest 27, I locked the peerDependency of Jest to `<= 26`.

This should fix #47 and #48 