### PR TITLE
Surface frame on failed Svelte compilation

### DIFF
--- a/src/transformer.js
+++ b/src/transformer.js
@@ -58,15 +58,26 @@ const process = (source, filename, jestOptions) => {
 const compiler = (format, options = {}, filename, processedCode, processedMap) => {
   const { debug, compilerOptions } = options
 
-  const result = svelte.compile(processedCode, {
-    filename: basename(filename),
-    css: true,
-    accessors: true,
-    dev: true,
-    format,
-    sourcemap: processedMap,
-    ...compilerOptions
-  })
+  let result;
+
+  try {
+    result = svelte.compile(processedCode, {
+      filename: basename(filename),
+      css: true,
+      accessors: true,
+      dev: true,
+      format,
+      sourcemap: processedMap,
+      ...compilerOptions
+    })
+  } catch(error) {
+    let msg = error.message;
+    if (error.frame) {
+      msg += '\n' + error.frame;
+    }
+    console.error(msg);
+    throw error;
+  }
 
   if (debug) {
     console.log(result.js.code)


### PR DESCRIPTION
When Svelte compiles a template, if it encounters an error in that template it attaches a `frame` variable to the exception showing where the error occurred.

Currently there's a bug in `svelte-preprocess` 4.9.0-4.9.4 which causes an invalid template and it was very difficult to figure out why. Had we surfaced the `frame` this would be much easier to figure out and would print:
```
      The $ prefix is reserved, and cannot be used for variable and import names
      3: exports.name = void 0;
      4: exports.name = "";
      5: var $$$$$$$$ = null;
         ^
      6: var $$vars$$ = [exports.name];</script>
      7: 
```

The `svelte-preprocess` case is a bit of a weird one. But you could imagine that the user had instead written their template in an invalid way. If this were the case it could be very difficult to figure out without this information. Probably they'd find out when building their project, but if they were trying to run the tests without rebuilding the project it could take them quite awhile to figure out what the issue is until they went to rebuild