### PR TITLE
fix: allow installation on Node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "author": "Rahim Alwer <rahim_alwer@hotmail.com>",
   "engines": {
-    "node": ">= 14"
+    "node": ">= 12"
   },
   "homepage": "https://github.com/mihar-22/svelte-jester#readme",
   "repository": {


### PR DESCRIPTION
Hotfix for #83, which fixes unsupported syntax on Node 12, but doesn't fix the engines, which can cause installation errors on package managers like Yarn