### PR TITLE
Fix for BUG 72 (OSX) - [ERR_INVALID_ARG_TYPE]: The "id" argument must…

### DIFF
--- a/src/transformer.js
+++ b/src/transformer.js
@@ -5,7 +5,7 @@ import * as svelte from 'svelte/compiler'
 
 import { getSvelteConfig } from './svelteconfig.js'
 
-const dynamicImport = async (filename) => import(pathToFileURL(filename))
+const dynamicImport = async (filename) => import(pathToFileURL(filename).toString())
 
 /**
  * Jest will only call this method when running in ESM mode.


### PR DESCRIPTION
Tested on OSX. 

hint: require expects string, pathToFileURL returns obj of URL type.