### PR TITLE
Fix issue with spaces in the project path

### DIFF
--- a/src/transformer.js
+++ b/src/transformer.js
@@ -44,7 +44,7 @@ const processSync = (source, filename, jestOptions) => {
   const preprocessor = require.resolve('./preprocess.js')
 
   const preprocessResult = execSync(
-        `node --unhandled-rejections=strict --abort-on-uncaught-exception ${preprocessor}`,
+        `node --unhandled-rejections=strict --abort-on-uncaught-exception "${preprocessor}"`,
         {
           env: { ...process.env, source, filename, svelteConfig, showConsoleLog },
           maxBuffer: maxBuffer || 10 * 1024 * 1024


### PR DESCRIPTION
The path to the preprocessor was being used in the command with surrounding quotes, which lead to it failing when there is a space in the path with errors like this:

```
Test suite failed to run

    Command failed: node --unhandled-rejections=strict --abort-on-uncaught-exception D:\University\Year 
4\<long path with more spaces>\node_modules\svelte-jester\dist\preprocess.js
    Uncaught Error: Cannot find module 'D:\University\Year'
```

This should fix the problem and allow for spaces in the path.