### PR TITLE
In some setups paths started with 'file://' cannot be found

### DIFF
--- a/src/transformer.js
+++ b/src/transformer.js
@@ -5,7 +5,7 @@ import * as svelte from 'svelte/compiler'
 
 import { getSvelteConfig } from './svelteconfig.js'
 
-const dynamicImport = async (filename) => import(pathToFileURL(filename).toString())
+const dynamicImport = async (filename) => import(pathToFileURL(filename).pathname)
 
 /**
  * Jest will only call this method when running in ESM mode.


### PR DESCRIPTION
Back to the same problem... Unfortunately i've found that in *some* specific setups (combination of packages/versions), users can get an error like file "file:///...." cannot be found.... Thus i think we need to replace .toString() based solution to more correct one - .pathname based one - it will generate accurate file path string for all the platforms... Tested on osx and windows.


