### PR TITLE
In some setups paths started with 'file://' cannot be found

### DIFF
--- a/src/transformer.js
+++ b/src/transformer.js
@@ -2,10 +2,10 @@ import { execSync } from 'child_process'
 import { basename } from 'path'
 import { pathToFileURL } from 'url'
 import * as svelte from 'svelte/compiler'
-
+import { platform } from 'os'
 import { getSvelteConfig } from './svelteconfig.js'
 
-const dynamicImport = async (filename) => import(pathToFileURL(filename).toString())
+const dynamicImport = async (filename) => import(platform() === "win32" ? pathToFileURL(filename).toString() : filename)
 
 /**
  * Jest will only call this method when running in ESM mode.


### PR DESCRIPTION
Back to the same problem... Unfortunately i've found that in some specific setups os (osx, linux) + (combination of packages/versions), users can get an error like file "file:///...." cannot be found.... Thus I think we need to keep pathToFileURL().toString() solution for windows only... Please consider.